### PR TITLE
docs: update example to prevent cyclic PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ jobs:
   push:
     name: Push Container
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci: Release')"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
If one implements both suggested workflows, then without this check, it tries to create a new release PR when a `ci: Release...` PR gets merged to `master`.